### PR TITLE
split failing test into separate test and make sure namespace_receive_callback_result returns with :ok

### DIFF
--- a/lib/wasmex.ex
+++ b/lib/wasmex.ex
@@ -94,7 +94,6 @@ defmodule Wasmex do
 
   @impl true
   def handle_info({:invoke_callback, namespace_name, import_name, params, token}, %{imports: imports} = state) do
-    # token = Wasmex.CallbackToken.wrap_resource(token)
     {success, return_value} = try do
       {_params, _returns, callback} = imports
                                       |> Map.get(namespace_name, %{})
@@ -104,7 +103,7 @@ defmodule Wasmex do
       e in RuntimeError -> {false, e.message}
     end
 
-    Wasmex.Native.namespace_receive_callback_result(token, success, [return_value])
+    :ok = Wasmex.Native.namespace_receive_callback_result(token, success, [return_value])
     {:noreply, state}
   end
 end

--- a/native/wasmex/src/instance.rs
+++ b/native/wasmex/src/instance.rs
@@ -162,7 +162,7 @@ pub fn decode_function_param_terms(
                     return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly i32 value.",
                         nth + 1
-                    ))
+                    ));
                 }
             }),
             (Type::I64, TermType::Number) => runtime::Value::I64(match given_param.decode() {
@@ -171,7 +171,7 @@ pub fn decode_function_param_terms(
                     return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly i64 value.",
                         nth + 1
-                    ))
+                    ));
                 }
             }),
             (Type::F32, TermType::Number) => {
@@ -190,7 +190,7 @@ pub fn decode_function_param_terms(
                         return Err(format!(
                             "Cannot convert argument #{} to a WebAssembly f32 value.",
                             nth + 1
-                        ))
+                        ));
                     }
                 })
             }
@@ -200,7 +200,7 @@ pub fn decode_function_param_terms(
                     return Err(format!(
                         "Cannot convert argument #{} to a WebAssembly f64 value.",
                         nth + 1
-                    ))
+                    ));
                 }
             }),
             (_, term_type) => {
@@ -208,7 +208,7 @@ pub fn decode_function_param_terms(
                     "Cannot convert argument #{} to a WebAssembly value. Given `{:?}`.",
                     nth + 1,
                     PrintableTermType::PrintTerm(term_type)
-                ))
+                ));
             }
         };
         function_params.push(value);

--- a/native/wasmex/src/namespace.rs
+++ b/native/wasmex/src/namespace.rs
@@ -152,9 +152,8 @@ pub fn receive_callback_result<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Te
     let success = atoms::success() == args[1];
     let results = args[2].decode::<ListIterator>()?;
 
-    //TODO: use real signature
-    let signature = std::sync::Arc::new(FuncSig::new(vec![Type::I32], vec![Type::I32]));
-    let results = match decode_function_param_terms(signature.returns(), results.collect()) {
+    let return_types = token_resource.token.3.clone();
+    let results = match decode_function_param_terms(&return_types, results.collect()) {
         Ok(v) => v,
         Err(_reason) => {
             return Err(Error::Atom(

--- a/native/wasmex/src/namespace.rs
+++ b/native/wasmex/src/namespace.rs
@@ -17,7 +17,6 @@ pub struct CallbackTokenResource {
         Mutex<Option<(bool, Vec<runtime::Value>)>>,
         Condvar,
         Vec<Type>,
-        Vec<Type>,
     ),
 }
 
@@ -93,12 +92,7 @@ fn create_imported_function(
         signature,
         move |_ctx: &mut Ctx, params: &[Value]| -> Vec<runtime::Value> {
             let callback_token = ResourceArc::new(CallbackTokenResource {
-                token: (
-                    Mutex::new(None),
-                    Condvar::new(),
-                    params_signature.clone(),
-                    results_signature.clone(),
-                ),
+                token: (Mutex::new(None), Condvar::new(), results_signature.clone()),
             });
 
             let mut msg_env = OwnedEnv::new();
@@ -152,7 +146,7 @@ pub fn receive_callback_result<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Te
     let success = atoms::success() == args[1];
     let results = args[2].decode::<ListIterator>()?;
 
-    let return_types = token_resource.token.3.clone();
+    let return_types = token_resource.token.2.clone();
     let results = match decode_function_param_terms(&return_types, results.collect()) {
         Ok(v) => v,
         Err(_reason) => {

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -132,8 +132,11 @@ defmodule WasmexTest do
     end
 
     test "call_function using_imported_sumf", %{instance: instance} do
-      assert {:ok, [4.2]} == Wasmex.call_function(instance, "using_imported_sumf", [2.3, 1.9])
-      assert {:ok, [2.3]} == Wasmex.call_function(instance, "using_imported_sumf", [10.0, -7.7])
+      {:ok, [result]} = Wasmex.call_function(instance, "using_imported_sumf", [2.3, 1.9])
+      assert_in_delta 4.2, result, 0.001
+
+      assert {:ok, [result]} = Wasmex.call_function(instance, "using_imported_sumf", [10.0, -7.7])
+      assert_in_delta 2.3, result, 0.001
     end
   end
 end

--- a/test/wasmex_test.exs
+++ b/test/wasmex_test.exs
@@ -113,19 +113,25 @@ defmodule WasmexTest do
   end
 
   describe "when instantiating with imports" do
-    test "call_functions using_imported_sum3 and using_imported_sumf" do
+    def create_instance_with_imports(_context) do
       imports = %{
         "env" => %{
           "imported_sum3" => {[:i32, :i32, :i32], [:i32], &(&1 + &2 + &3)},
           "imported_sumf" => {[:f32, :f32], [:f32], &(&1 + &2)}
         }
       }
-
       instance = start_supervised!({Wasmex, %{bytes: @import_test_bytes, imports: imports}})
+      %{instance: instance}
+    end
 
+    setup [:create_instance_with_imports]
+
+    test "call_function using_imported_sum3", %{instance: instance} do
       assert {:ok, [44]} == Wasmex.call_function(instance, "using_imported_sum3", [23, 19, 2])
       assert {:ok, [28]} == Wasmex.call_function(instance, "using_imported_sum3", [100, -77, 5])
+    end
 
+    test "call_function using_imported_sumf", %{instance: instance} do
       assert {:ok, [4.2]} == Wasmex.call_function(instance, "using_imported_sumf", [2.3, 1.9])
       assert {:ok, [2.3]} == Wasmex.call_function(instance, "using_imported_sumf", [10.0, -7.7])
     end


### PR DESCRIPTION
@myobie I think it is the return values conversion still using a hardcoded signature.
We forgot to check the result (in elixir) of the `Wasmex.Native.namespace_receive_callback_result` call and just assumed it always goes well. Instead it returns a proper error and we should check/fail it.